### PR TITLE
Updating examples to include throughout how it works section

### DIFF
--- a/_includes/customStyle.html
+++ b/_includes/customStyle.html
@@ -26,11 +26,11 @@
 }
 
 /* WET Overrides */
-.checkbox input[type=checkbox] {
-    margin-left: 0;
+.checkbox-inline input[type=checkbox] {
+    margin-left: -35px;
 }
-.checkbox label {
-    padding-left: 30px;
+.checkbox-inline label {
+    padding-left: 15px;
 }
 label.required:after {
     content: " (required)";

--- a/_includes/customStyle.html
+++ b/_includes/customStyle.html
@@ -37,4 +37,11 @@ label.required:after {
     color: #d3080c;
     font-weight: 700;
 }
+details, details[open], details>summary {
+    background-color: lightgray;
+    border: 1px solid black;
+}
+details[open]>summary {
+    border-bottom: 1px dotted black;
+}
 </style>

--- a/_includes/customStyle.html
+++ b/_includes/customStyle.html
@@ -37,11 +37,4 @@ label.required:after {
     color: #d3080c;
     font-weight: 700;
 }
-details, details[open], details>summary {
-    background-color: lightgray;
-    border: 1px solid black;
-}
-details[open]>summary {
-    border-bottom: 1px dotted black;
-}
 </style>

--- a/_patterns/opt-in-fr.md
+++ b/_patterns/opt-in-fr.md
@@ -49,24 +49,26 @@ Veillez à utiliser les niveaux de titre appropriés, généralement un `h2` est
 
 <details>
     <summary>Exemple de déclaration de confidentialité</summary>
-    <p class="h2">Politique de confidentialité</p>
-    <p><em>[Vous pouvez ajouter ici une déclaration de confidentialité personnalisée qui respecte la politique de confidentialité du gouvernement du Canada. Elle doit indiquer clairement comment les informations personnelles de l'utilisateur <strong>seront ou ne seront pas</strong> utilisées. Des exemples suivent.]</em></p>
-    <p>YVos informations <strong>ne seront pas</strong> utilisées dans le cadre d'un processus décisionnelqui affecte votre accès aux services du Gouvernement du Canada. Vos renseignements personnels <strong>ne seront pas</strong> utilisés à des fins administratives.</p>
-    <p>os renseignements personnels et vos commentaires sont confidentiels.</p>
-    <p>Vos renseignements <strong>seront</strong> utilisés par Emploi et Développement Social Canada pour <em>[expliquer brièvement à quoi serviront les renseignements]</em>.</p>
-    <p class="h3">Ce que nous allons recueillir</p>
-    <p>Nous avons besoin des renseignements suivants pour <em>[expliquer brièvement pourquoi vous avez besoin des données suivantes]</em>:</p>
-    <ul>
-        <li>Adresse de courriel</li>
-        <li><em>[ndiquez d'autres données d'identification personnelle obligatoires]</em></li>
-    </ul>
-    <p>Vous pouvez également choisir de nous communiquer d'autres renseignements pour que nous puissions <em>[expliquer brièvement comment le fait de fournir les données suivantes permettra de fournir des services à l'utilisateur]</em>:</p>
-    <ul>
-        <li>Province ou territoire</li>
-        <li><em>[Indiquez d'autres données d'identification personnelle facultatives]</em></li>
-    </ul>
-    <p>Nous recueillons ces renseignements pour nous assurer que nos groupes de recherche sont diversifiés et pour déterminer les tendances en matière de rétroaction pour des groupes particuliers.</p>
-    <p><a href="https://www.canada.ca/fr/transparence/confidentialite.html">Lisez la politique de confidentialité complète.</a></p>
+    <div class="row well well-sm mrgn-bttm-0">
+        <p class="h2 mrgn-tp-sm">Politique de confidentialité</p>
+        <p><em>[Vous pouvez ajouter ici une déclaration de confidentialité personnalisée qui respecte la politique de confidentialité du gouvernement du Canada. Elle doit indiquer clairement comment les informations personnelles de l'utilisateur <strong>seront ou ne seront pas</strong> utilisées. Des exemples suivent.]</em></p>
+        <p>YVos informations <strong>ne seront pas</strong> utilisées dans le cadre d'un processus décisionnelqui affecte votre accès aux services du Gouvernement du Canada. Vos renseignements personnels <strong>ne seront pas</strong> utilisés à des fins administratives.</p>
+        <p>os renseignements personnels et vos commentaires sont confidentiels.</p>
+        <p>Vos renseignements <strong>seront</strong> utilisés par Emploi et Développement Social Canada pour <em>[expliquer brièvement à quoi serviront les renseignements]</em>.</p>
+        <p class="h3">Ce que nous allons recueillir</p>
+        <p>Nous avons besoin des renseignements suivants pour <em>[expliquer brièvement pourquoi vous avez besoin des données suivantes]</em>:</p>
+        <ul>
+            <li>Adresse de courriel</li>
+            <li><em>[ndiquez d'autres données d'identification personnelle obligatoires]</em></li>
+        </ul>
+        <p>Vous pouvez également choisir de nous communiquer d'autres renseignements pour que nous puissions <em>[expliquer brièvement comment le fait de fournir les données suivantes permettra de fournir des services à l'utilisateur]</em>:</p>
+        <ul>
+            <li>Province ou territoire</li>
+            <li><em>[Indiquez d'autres données d'identification personnelle facultatives]</em></li>
+        </ul>
+        <p>Nous recueillons ces renseignements pour nous assurer que nos groupes de recherche sont diversifiés et pour déterminer les tendances en matière de rétroaction pour des groupes particuliers.</p>
+        <p><a href="https://www.canada.ca/fr/transparence/confidentialite.html">Lisez la politique de confidentialité complète.</a></p>
+    </div>
 </details>
 
 ### Description de l'option de refus
@@ -76,8 +78,10 @@ La section doit commencer par un titre de même niveau que la déclaration de co
 
 <details>
     <summary>Exemple de description de désabonnement</summary>
-    <p class="h2">Comment se désabonner de <em>[identifier de quoi l'utilisateur se désabonne]</em></p>
-    <p>Si vous vous êtes précédemment inscrit pour devenir un participant et que vous ne souhaitez plus être contacté à l'avenir <em>[expliquez en détail ce dont l'utilisateur se désabonne]</em>, vous pouvez vous <a href="#desabonner">désabonner</a> de la liste des participants et nous supprimerons vos informations personnelles.</p>
+    <div class="row well well-sm mrgn-bttm-0">
+        <p class="h2 mrgn-tp-sm">Comment se désabonner de <em>[identifier de quoi l'utilisateur se désabonne]</em></p>
+        <p>Si vous vous êtes précédemment inscrit pour devenir un participant et que vous ne souhaitez plus être contacté à l'avenir <em>[expliquez en détail ce dont l'utilisateur se désabonne]</em>, vous pouvez vous <a href="#desabonner">désabonner</a> de la liste des participants et nous supprimerons vos informations personnelles.</p>
+    </div>
 </details>
 
 ### Action affirmative
@@ -86,13 +90,15 @@ Action affirmative que l'utilisateur peut entreprendre pour accepter la déclara
 
 <details>
     <summary>Exemple de action affirmative</summary>
-    <div class="checkbox-inline">
-        <label for="consent" class="required">
-            <input type="checkbox" id="consent" name="consent" value="consent">
-            <strong>J'affirme que j'ai 18 ans ou plus. Je comprends que je peux me retirer de ce <em>[nom duservice]</em> à tout moment sans conséquence.</strong>
-        </label>
+    <div class="row well well-sm mrgn-bttm-0">
+        <div class="checkbox-inline">
+            <label for="consent" class="required">
+                <input type="checkbox" id="consent" name="consent" value="consent">
+                <strong>J'affirme que j'ai 18 ans ou plus. Je comprends que je peux me retirer de ce <em>[nom duservice]</em> à tout moment sans conséquence.</strong>
+            </label>
+        </div>
+        <p><em>Le balisage html valide pour une case à cocher standard doit être examiné et se trouve dans le <a href="https://wet-boew.github.io/wet-boew-styleguide/design/forms-fr#checkboxes" target="_blank">Boîte à outils de l'expérience Web</a>.</em></p>
     </div>
-    <p><em>Le balisage html valide pour une case à cocher standard doit être examiné et se trouve dans le <a href="https://wet-boew.github.io/wet-boew-styleguide/design/forms-fr#checkboxes" target="_blank">Boîte à outils de l'expérience Web</a>.</em></p>
 </details>
 
 ## Modèles et composants connexes

--- a/_patterns/opt-in-fr.md
+++ b/_patterns/opt-in-fr.md
@@ -73,7 +73,7 @@ Veillez à utiliser les niveaux de titre appropriés, généralement un `h2` est
 
 ### Description de l'option de refus
 
-Une brève description de la manière de refuser, de corriger ou de supprimer ses données ultérieurement. 
+Une brève description de la manière de refuser, de corriger ou de supprimer ses données ultérieurement.
 La section doit commencer par un titre de même niveau que la déclaration de confidentialité, généralement un `h2`.
 
 <details>

--- a/_patterns/opt-in-fr.md
+++ b/_patterns/opt-in-fr.md
@@ -38,77 +38,62 @@ N'utilisez pas ce modèle lorsque :
 * L'utilisateur n'est pas en mesure de voir ou d'accéder aux autres données que l'organisation collecte et à leurs finalités ou utilisations.
 * Il n'existe pas de procédure claire permettant à l'utilisateur de refuser, de corriger ou de supprimer ses données à tout moment.
 
-## Comment ça fonctionne?
+## Comment ça fonctionne
 
-Lorsque vous collectez les données d'un utilisateur, assurez-vous que les éléments suivants sont **présents, faciles à trouver, à lire et à utiliser**.
+orsque vous collectez les données d'un utilisateur, assurez-vous que les éléments suivants sont **présents, faciles à trouver, à lire et à utiliser**.
 
-* Une déclaration de confidentialité résumée mettant en évidence le(s) types de collecte, de stockage et d'utilisation des données, avec des liens vers la déclaration complète.
-* Une brève description de la manière de se désinscrire, de corriger ou de supprimer leurs données ultérieurement.
-* Une action positive que l'utilisateur peut prendre pour accepter la déclaration de confidentialité (c'est-à-dire une case à cocher qui n'est pas présélectionnée).
+### Déclaration de confidentialité
 
-## Recherche et impacts
+Une déclaration de confidentialité résumée mettant en évidence le(s) type(s) de collecte, de stockage et d'utilisation des données, avec des liens vers la déclaration complète.
+Veillez à utiliser les niveaux de titre appropriés, généralement un `h2` est utilisé.
 
-Bientôt disponible
+<details>
+    <summary>Exemple de déclaration de confidentialité</summary>
+    <p class="h2">Politique de confidentialité</p>
+    <p><em>[Vous pouvez ajouter ici une déclaration de confidentialité personnalisée qui respecte la politique de confidentialité du gouvernement du Canada. Elle doit indiquer clairement comment les informations personnelles de l'utilisateur <strong>seront ou ne seront pas</strong> utilisées. Des exemples suivent.]</em></p>
+    <p>YVos informations <strong>ne seront pas</strong> utilisées dans le cadre d'un processus décisionnelqui affecte votre accès aux services du Gouvernement du Canada. Vos renseignements personnels <strong>ne seront pas</strong> utilisés à des fins administratives.</p>
+    <p>os renseignements personnels et vos commentaires sont confidentiels.</p>
+    <p>Vos renseignements <strong>seront</strong> utilisés par Emploi et Développement Social Canada pour <em>[expliquer brièvement à quoi serviront les renseignements]</em>.</p>
+    <p class="h3">Ce que nous allons recueillir</p>
+    <p>Nous avons besoin des renseignements suivants pour <em>[expliquer brièvement pourquoi vous avez besoin des données suivantes]</em>:</p>
+    <ul>
+        <li>Adresse de courriel</li>
+        <li><em>[ndiquez d'autres données d'identification personnelle obligatoires]</em></li>
+    </ul>
+    <p>Vous pouvez également choisir de nous communiquer d'autres renseignements pour que nous puissions <em>[expliquer brièvement comment le fait de fournir les données suivantes permettra de fournir des services à l'utilisateur]</em>:</p>
+    <ul>
+        <li>Province ou territoire</li>
+        <li><em>[Indiquez d'autres données d'identification personnelle facultatives]</em></li>
+    </ul>
+    <p>Nous recueillons ces renseignements pour nous assurer que nos groupes de recherche sont diversifiés et pour déterminer les tendances en matière de rétroaction pour des groupes particuliers.</p>
+    <p><a href="https://www.canada.ca/fr/transparence/confidentialite.html">Lisez la politique de confidentialité complète.</a></p>
+</details>
 
-## Exemples
+### Description de l'option de refus
 
-### Collecte des données démographiques des utilisateurs pour la recherche sur Canada.ca
+Une brève description de la manière de refuser, de corriger ou de supprimer ses données ultérieurement. 
+La section doit commencer par un titre de même niveau que la déclaration de confidentialité, généralement un `h2`.
 
-<!-- IMPORTANT - Ajoutez des liens vers le SCL et inscrivez-vous une fois en ligne ! -->
+<details>
+    <summary>Exemple de description de désabonnement</summary>
+    <p class="h2">Comment se désabonner de <em>[identifier de quoi l'utilisateur se désabonne]</em></p>
+    <p>Si vous vous êtes précédemment inscrit pour devenir un participant et que vous ne souhaitez plus être contacté à l'avenir <em>[expliquez en détail ce dont l'utilisateur se désabonne]</em>, vous pouvez vous <a href="#desabonner">désabonner</a> de la liste des participants et nous supprimerons vos informations personnelles.</p>
+</details>
 
-Service Canada Labs - un site d’essai pour les idées expérimentales et les travaux en cours - invite les utilisateurs à s'inscrire pour aider à améliorer ce travail en participant à des activités de recherche.
+### Action affirmative
 
-Le formulaire d'inscription demande aux utilisateurs de partager certaines informations de contact obligatoires et certaines informations démographiques facultatives.
+Action affirmative que l'utilisateur peut entreprendre pour accepter la déclaration de confidentialité (par exemple, une case à cocher qui n'est pas présélectionnée).
 
-Lors de la collecte des données démographiques des utilisateurs à des fins de recherche sur Canada.ca (et sur des sites connexes comme Service Canada Labs), les éléments suivants doivent être inclus sur la même page que le formulaire de collecte des données.
-
-> **Politique en matière de protection des renseignements personnels**
->
-> Vos renseignements personnels ne seront pas utilisés dans le cadre d'un processus décisionnel qui vous touche directement ou qui vous donne accès aux services du gouvernement du Canada.
-> Vos renseignements ne seront pas utilisés à des fins administratives.
->
-> Votre participation est volontaire.
-> Vous pouvez retirer votre participation et vos renseignements personnels de notre liste à tout moment, sans aucune conséquence sur votre accès aux services ou prestations du gouvernement.
->
-> Vos renseignements personnels et vos commentaires sont confidentiels.
->
-> Vos renseignements seront utilisés par Emploi et Développement social Canada à des fins d'analyse des politiques, de recherche et d'évaluation.
->
-> **Ce que nous allons recueillir**
->
-> Nous avons besoin des renseignements suivants pour pouvoir communiquer avec vous :
->
-> * Adresse de courrier électronique
-> * Année de naissance
-> * Langue de votre choix
->
-> Vous pouvez également choisir d’échanger plus de renseignements avec nous afin que nous puissions vous inviter à participer à des recherches en fonction de vos expériences de vie :
->
-> * Province ou territoire
-> * Identité de genre
-> * Identité autochtone
-> * Situation de handicap
-> * Groupe de minorité visible
-> * Niveau de revenus
->
-> Nous recueillons ces informations pour nous assurer que nos groupes de recherche sont diversifiés et pour identifier les tendances dans les commentaires de groupes spécifiques.
->
-> [Lire la politique en matière de protection des renseignements personnels dans son intégralité.](https://www.canada.ca/fr/transparence/confidentialite.html)
->
-> **Comment se désinscrire des invitations à participer aux recherches**
->
-> Si vous vous êtes déjà inscrit pour participer et que vous ne souhaitez plus être contacté pour de futures recherches, vous pouvez vous [désinscrire](#desinscrire) et nous supprimerons vos renseignements personnels.
->
-> _Mettez votre formulaire ici._
->
-> <div class="checkbox">
-> <input type="checkbox" id="consent" name="consent" value="consent">
-> <label for="consent" class="required"><strong>J’ai lu, compris et accepté ce qui précède. J’affirme que j’ai 18 ans ou plus. Je comprends que je peux me retirer de ce groupe de participants ou de toute étude de recherche à tout moment, sans conséquence.</strong></label>
-> </div>
-
-Une fois que l'utilisateur accepte que ses données soient collectées et soumet le formulaire, le formulaire transmet ces informations à une base de données où elles sont stockées.
-
-Pour en savoir plus sur les éléments techniques qui composent le formulaire d'inscription de Service Canada Labs, lisez cette [documentation de conception](https://github.com/DTS-STN/Alpha-Site/wiki/Design-Doc-004-Screener-Intake-Process).
+<details>
+    <summary>Exemple de action affirmative</summary>
+    <div class="checkbox-inline">
+        <label for="consent" class="required">
+            <input type="checkbox" id="consent" name="consent" value="consent">
+            <strong>J'affirme que j'ai 18 ans ou plus. Je comprends que je peux me retirer de ce <em>[nom duservice]</em> à tout moment sans conséquence.</strong>
+        </label>
+    </div>
+    <p><em>Le balisage html valide pour une case à cocher standard doit être examiné et se trouve dans le <a href="https://wet-boew.github.io/wet-boew-styleguide/design/forms-fr#checkboxes" target="_blank">Boîte à outils de l'expérience Web</a>.</em></p>
+</details>
 
 ## Modèles et composants connexes
 

--- a/_patterns/opt-in.md
+++ b/_patterns/opt-in.md
@@ -92,7 +92,7 @@ An affirmative action the user can take to opt-in by agreeing to the privacy sta
             <strong>I have read, understood and agree to the above. I affirm that I am 18 years old, or older. I understand that I can withdraw from this <em>[service name]</em> at any time without consequence.</strong>
         </label>
     </div>
-    <p><em>Valid html markup for a standard checkbox should be reviewed, and can be found in the <a href="https://wet-boew.github.io/wet-boew-styleguide/design/forms-en.html#checkboxes" target="_blank">wet-boew style guide</a>.</em></p>
+    <p><em>Valid html markup for a standard checkbox should be reviewed, and can be found in the <a href="https://wet-boew.github.io/wet-boew-styleguide/design/forms-en.html#checkboxes" target="_blank">Web Experience Toolkit</a>.</em></p>
 </details>
 
 ## Research and impacts

--- a/_patterns/opt-in.md
+++ b/_patterns/opt-in.md
@@ -50,20 +50,20 @@ Be sure to use proper heading levels, typically a `h2` is used.
 <details>
     <summary>Example of a privacy statement</summary>
     <p class="h2">Privacy policy</p>
-    <p><em>You can add a custom privacy statement here that adheres to the Government of Canada privacy. It should be clear how the users personal information <strong>will and will not</strong> be used. Examples follow.</em></p>    
+    <p><em>[You can add a custom privacy statement here that adheres to the Government of Canada privacy. It should be clear how the users personal information <strong>will and will not</strong> be used. Examples follow.]</em></p>    
     <p>Your information <strong>will not</strong> be used for any decision-making process that affects your access to Government of Canada services. Your personal information <strong>will not</strong> be used for any administrative purposes.</p>
     <p>Your personal information and feedback is confidential.</p>
-    <p>Your information <strong>will</strong> be used by Employment and Social Development Canada for...</p>
+    <p>Your information <strong>will</strong> be used by Employment and Social Development Canada for <em>[Briefly explain what the information will be used for]</em>.</p>
     <p class="h3">What we will collect</p>
-    <p>We need the following information so we can ...:</p>
+    <p>We need the following information so we can <em>[Briefly explain why you need the following data]</em>:</p>
     <ul>
         <li>Email address</li>
-        <li><em>List more mandatory personal identifying felids</em></li>
+        <li><em>[List more mandatory personal identifying felids]</em></li>
     </ul>
-    <p>You can also choose to share more information with us so we can ...:</p>
+    <p>You can also choose to share more information with us so we can <em>[Briefly explain how providing the following data will enable services for the user]</em>:</p>
     <ul>
         <li>Province or territory</li>
-        <li><em>List more optional personal identifying felids</em></li>
+        <li><em>[List more optional personal identifying felids]</em></li>
     </ul>
     <p>We collect this information to ensure our research groups are diverse, and to identify trends in feedback for specific groups.</p>
     <p><a href="https://www.canada.ca/en/transparency/privacy.html">Read the full privacy policy.</a></p>
@@ -76,8 +76,8 @@ The section should start with the same level heading as the Privacy statement, t
 
 <details>
     <summary>Example of an opt-out description</summary>
-    <p class="h2">How to unsubscribe from ...</p>
-    <p>If you have previously signed up to become a participant and no longer wish to be contacted for future ..., you can <a href="#unsubscribe">unsubscribe</a> yourself from the participant list and we will remove your personal information.</p>
+    <p class="h2">How to unsubscribe from <em>[identify what the user is unsubscribing from]</em></p>
+    <p>If you have previously signed up to become a participant and no longer wish to be contacted for future <em>[explain in detail what the user is unsubscribing from]</em>, you can <a href="#unsubscribe">unsubscribe</a> yourself from the participant list and we will remove your personal information.</p>
 </details>
 
 ### Affirmative action
@@ -89,7 +89,7 @@ An affirmative action the user can take to opt-in by agreeing to the privacy sta
     <div class="checkbox-inline">
         <label for="consent" class="required">
             <input type="checkbox" id="consent" name="consent" value="consent">
-            <strong>I have read, understood and agree to the above. I affirm that I am 18 years old, or older. I understand that I can withdraw from this ... at any time without consequence.</strong>
+            <strong>I have read, understood and agree to the above. I affirm that I am 18 years old, or older. I understand that I can withdraw from this <em>[service name]</em> at any time without consequence.</strong>
         </label>
     </div>
     <p><em>Valid html markup for a standard checkbox should be reviewed, and can be found in the <a href="https://wet-boew.github.io/wet-boew-styleguide/design/forms-en.html#checkboxes" target="_blank">wet-boew style guide</a>.</em></p>

--- a/_patterns/opt-in.md
+++ b/_patterns/opt-in.md
@@ -50,7 +50,7 @@ Be sure to use proper heading levels, typically a `h2` is used.
 <details>
     <summary>Example of a privacy statement</summary>
     <p class="h2">Privacy policy</p>
-    <p><em>[You can add a custom privacy statement here that adheres to the Government of Canada privacy. It should be clear how the users personal information <strong>will and will not</strong> be used. Examples follow.]</em></p>    
+    <p><em>[You can add a custom privacy statement here that adheres to the Government of Canada privacy. It should be clear how the users personal information <strong>will and will not</strong> be used. Examples follow.]</em></p>
     <p>Your information <strong>will not</strong> be used for any decision-making process that affects your access to Government of Canada services. Your personal information <strong>will not</strong> be used for any administrative purposes.</p>
     <p>Your personal information and feedback is confidential.</p>
     <p>Your information <strong>will</strong> be used by Employment and Social Development Canada for <em>[Briefly explain what the information will be used for]</em>.</p>

--- a/_patterns/opt-in.md
+++ b/_patterns/opt-in.md
@@ -49,24 +49,26 @@ Be sure to use proper heading levels, typically a `h2` is used.
 
 <details>
     <summary>Example of a privacy statement</summary>
-    <p class="h2">Privacy policy</p>
-    <p><em>[You can add a custom privacy statement here that adheres to the Government of Canada privacy. It should be clear how the users personal information <strong>will and will not</strong> be used. Examples follow.]</em></p>
-    <p>Your information <strong>will not</strong> be used for any decision-making process that affects your access to Government of Canada services. Your personal information <strong>will not</strong> be used for any administrative purposes.</p>
-    <p>Your personal information and feedback is confidential.</p>
-    <p>Your information <strong>will</strong> be used by Employment and Social Development Canada for <em>[Briefly explain what the information will be used for]</em>.</p>
-    <p class="h3">What we will collect</p>
-    <p>We need the following information so we can <em>[Briefly explain why you need the following data]</em>:</p>
-    <ul>
-        <li>Email address</li>
-        <li><em>[List more mandatory personal identifying felids]</em></li>
-    </ul>
-    <p>You can also choose to share more information with us so we can <em>[Briefly explain how providing the following data will enable services for the user]</em>:</p>
-    <ul>
-        <li>Province or territory</li>
-        <li><em>[List more optional personal identifying felids]</em></li>
-    </ul>
-    <p>We collect this information to ensure our research groups are diverse, and to identify trends in feedback for specific groups.</p>
-    <p><a href="https://www.canada.ca/en/transparency/privacy.html">Read the full privacy policy.</a></p>
+    <div class="row well well-sm mrgn-bttm-0">
+        <p class="h2 mrgn-tp-sm">Privacy policy</p>
+        <p><em>[You can add a custom privacy statement here that adheres to the Government of Canada privacy. It should be clear how the users personal information <strong>will and will not</strong> be used. Examples follow.]</em></p>
+        <p>Your information <strong>will not</strong> be used for any decision-making process that affects your access to Government of Canada services. Your personal information <strong>will not</strong> be used for any administrative purposes.</p>
+        <p>Your personal information and feedback is confidential.</p>
+        <p>Your information <strong>will</strong> be used by Employment and Social Development Canada for <em>[Briefly explain what the information will be used for]</em>.</p>
+        <p class="h3">What we will collect</p>
+        <p>We need the following information so we can <em>[Briefly explain why you need the following data]</em>:</p>
+        <ul>
+            <li>Email address</li>
+            <li><em>[List more mandatory personal identifying felids]</em></li>
+        </ul>
+        <p>You can also choose to share more information with us so we can <em>[Briefly explain how providing the following data will enable services for the user]</em>:</p>
+        <ul>
+            <li>Province or territory</li>
+            <li><em>[List more optional personal identifying felids]</em></li>
+        </ul>
+        <p>We collect this information to ensure our research groups are diverse, and to identify trends in feedback for specific groups.</p>
+        <p><a href="https://www.canada.ca/en/transparency/privacy.html">Read the full privacy policy.</a></p>
+    </div>
 </details>
 
 ### Opt-out description
@@ -76,8 +78,10 @@ The section should start with the same level heading as the Privacy statement, t
 
 <details>
     <summary>Example of an opt-out description</summary>
-    <p class="h2">How to unsubscribe from <em>[identify what the user is unsubscribing from]</em></p>
-    <p>If you have previously signed up to become a participant and no longer wish to be contacted for future <em>[explain in detail what the user is unsubscribing from]</em>, you can <a href="#unsubscribe">unsubscribe</a> yourself from the participant list and we will remove your personal information.</p>
+    <div class="row well well-sm mrgn-bttm-0">
+        <p class="h2 mrgn-tp-sm">How to unsubscribe from <em>[identify what the user is unsubscribing from]</em></p>
+        <p>If you have previously signed up to become a participant and no longer wish to be contacted for future <em>[explain in detail what the user is unsubscribing from]</em>, you can <a href="#unsubscribe">unsubscribe</a> yourself from the participant list and we will remove your personal information.</p>
+    </div>
 </details>
 
 ### Affirmative action
@@ -86,13 +90,15 @@ An affirmative action the user can take to opt-in by agreeing to the privacy sta
 
 <details>
     <summary>Example of an affirmative action</summary>
-    <div class="checkbox-inline">
-        <label for="consent" class="required">
-            <input type="checkbox" id="consent" name="consent" value="consent">
-            <strong>I have read, understood and agree to the above. I affirm that I am 18 years old, or older. I understand that I can withdraw from this <em>[service name]</em> at any time without consequence.</strong>
-        </label>
+    <div class="row well well-sm mrgn-bttm-0">
+        <div class="checkbox-inline">
+            <label for="consent" class="required">
+                <input type="checkbox" id="consent" name="consent" value="consent">
+                <strong>I have read, understood and agree to the above. I affirm that I am 18 years old, or older. I understand that I can withdraw from this <em>[service name]</em> at any time without consequence.</strong>
+            </label>
+        </div>
+        <p><em>Valid html markup for a standard checkbox should be reviewed, and can be found in the <a href="https://wet-boew.github.io/wet-boew-styleguide/design/forms-en.html#checkboxes" target="_blank">Web Experience Toolkit</a>.</em></p>
     </div>
-    <p><em>Valid html markup for a standard checkbox should be reviewed, and can be found in the <a href="https://wet-boew.github.io/wet-boew-styleguide/design/forms-en.html#checkboxes" target="_blank">Web Experience Toolkit</a>.</em></p>
 </details>
 
 ## Research and impacts

--- a/_patterns/opt-in.md
+++ b/_patterns/opt-in.md
@@ -42,73 +42,62 @@ Don't use this pattern when:
 
 When you collect a user's data, make sure the following are **present, easy to find, read, and use**.
 
-* A summarized privacy statement highlighting the type(s) of data collection, storage, and use, with links to the full statement.
-* A short description of how to opt-out, correct, or delete their data later.
-* An affirmative action the user can take to opt-in by aggreeing to the privacy statement (i.e. a checkbox that isn't pre-selected).
+### Privacy statement
+
+A summarized privacy statement highlighting the type(s) of data collection, storage, and use, with links to the full statement.
+Be sure to use proper heading levels, typically a `h2` is used.  
+
+<details>
+    <summary>Example of a privacy statement</summary>
+    <p class="h2">Privacy policy</p>
+    <p><em>You can add a custom privacy statement here that adheres to the Government of Canada privacy. It should be clear how the users personal information <strong>will and will not</strong> be used. Examples follow.</em></p>    
+    <p>Your information <strong>will not</strong> be used for any decision-making process that affects your access to Government of Canada services. Your personal information <strong>will not</strong> be used for any administrative purposes.</p>
+    <p>Your personal information and feedback is confidential.</p>
+    <p>Your information <strong>will</strong> be used by Employment and Social Development Canada for...</p>
+    <p class="h3">What we will collect</p>
+    <p>We need the following information so we can ...:</p>
+    <ul>
+        <li>Email address</li>
+        <li><em>List more mandatory personal identifying felids</em></li>
+    </ul>
+    <p>You can also choose to share more information with us so we can ...:</p>
+    <ul>
+        <li>Province or territory</li>
+        <li><em>List more optional personal identifying felids</em></li>
+    </ul>
+    <p>We collect this information to ensure our research groups are diverse, and to identify trends in feedback for specific groups.</p>
+    <p><a href="https://www.canada.ca/en/transparency/privacy.html">Read the full privacy policy.</a></p>
+</details>
+
+### Opt-out description
+
+A short description of how to opt-out, correct, or delete their data later.
+The section should start with the same level heading as the Privacy statement, typically a `h2`.
+
+<details>
+    <summary>Example of an opt-out description</summary>
+    <p class="h2">How to unsubscribe from ...</p>
+    <p>If you have previously signed up to become a participant and no longer wish to be contacted for future ..., you can <a href="#unsubscribe">unsubscribe</a> yourself from the participant list and we will remove your personal information.</p>
+</details>
+
+### Affirmative action
+
+An affirmative action the user can take to opt-in by agreeing to the privacy statement (i.e. a checkbox that isn't pre-selected).
+
+<details>
+    <summary>Example of an affirmative action</summary>
+    <div class="checkbox-inline">
+        <label for="consent" class="required">
+            <input type="checkbox" id="consent" name="consent" value="consent">
+            <strong>I have read, understood and agree to the above. I affirm that I am 18 years old, or older. I understand that I can withdraw from this ... at any time without consequence.</strong>
+        </label>
+    </div>
+    <p><em>Valid html markup for a standard checkbox should be reviewed, and can be found in the <a href="https://wet-boew.github.io/wet-boew-styleguide/design/forms-en.html#checkboxes" target="_blank">wet-boew style guide</a>.</em></p>
+</details>
 
 ## Research and impacts
 
 Coming soon
-
-## Examples
-
-### Collecting users' demographic data for research on Canada.ca
-
-<!-- IMPORTANT - Add links to SCL and sign up once live! -->
-
-Service Canada Labs - a test site for experimental ideas and works in progress - invites users to sign up to help improve that work by participating in research activities.
-
-The sign up form asks users to share some mandatory contact information and some optional demographic information.
-
-When collecting users' demographic data for research on Canada.ca (and related sites like Service Canada Labs), the following components should be included on the same page as the form collecting the data.
-
-> **Privacy policy**
->
-> Your information will not be used for any decision-making process that affects your access to Government of Canada services.
-> Your personal information will not be used for any administrative purposes.
->
-> Your participation is completely voluntary.
-> You can withdraw your participation and personal information from our list at any time with no impact on your access to government services or benefits.
->
-> Your personal information and feedback is confidential.
->
-> Your information will be used by Employment and Social Development Canada for policy analysis, research, and evaluation purposes.
->
-> **What we will collect**
->
-> We need the following information so we can contact you:
->
-> * Email address
-> * Year of birth
-> * Language preference
->
-> You can also choose to share more information with us so we can invite you to research and testing opportunities based on your life experiences:
->
-> * Province or territory
-> * Gender identity
-> * Indigenous identity
-> * Disabilities
-> * Visible Minority group
-> * Income range
->
-> We collect this information to ensure our research groups are diverse, and to identify trends in feedback for specific groups.
->
-> [Read the full privacy policy.](https://www.canada.ca/en/transparency/privacy.html)
->
-> **How to unsubscribe from research invites**
->
-> If you have previously signed up to become a participant and no longer wish to be contacted for future research studies, you can [unsubscribe](#unsubscribe) yourself from the participant list and we will remove your personal information.
->
-> _Put your form here._
->
-> <div class="checkbox">
-> <input type="checkbox" id="consent" name="consent" value="consent">
-> <label for="consent" class="required"><strong>I have read, understood and agree to the above. I affirm that I am 18 years old, or older. I understand that I can withdraw from this participant pool, or any research study at any time without consequence.</strong></label>
-> </div>
-
-Once the user consents to their data being collected and submits the form, the form passes that information to a database where it is stored.
-
-To learn about the technical components that make up Service Canada Labs' sign up form, read this [design documentation](https://github.com/DTS-STN/Alpha-Site/wiki/Design-Doc-004-Screener-Intake-Process).
 
 ## Related patterns and components
 


### PR DESCRIPTION
Just playing with some ideas at the moment. Trying to remove the direct links to SC Labs to be more generic.
I'm not sure how to deal with the `...` where we want someone to input their own words/text.