### PR TITLE
Remove alt text so images are marked as decorative

### DIFF
--- a/_includes/pattern-cards.html
+++ b/_includes/pattern-cards.html
@@ -5,7 +5,7 @@
         <a class="figcaption hght-inhrt" href="{{ pattern.url | relative_url }}">
             <figure class="well well-sm hght-inhrt">
                 {% if pattern.feature-img-path %}
-                <img class="img-responsive full-width" alt="{{ pattern.feature-img-alt }}" src="{{ pattern.feature-img-path }}">
+                <img class="img-responsive full-width" alt="" src="{{ pattern.feature-img-path }}">
                 {% endif %}
                 <figcaption>
                     <div class="h4 link">{{ pattern.name }}</div>

--- a/_includes/pattern-summary.html
+++ b/_includes/pattern-summary.html
@@ -7,7 +7,7 @@
 </section>
 
 <div class="col-sm-4 pull-right">
-    <img class="img-responsive" alt="{{ page.feature-img-alt }}" src="{{ page.feature-img-path | relative_url }}">
+    <img class="img-responsive" alt="" src="{{ page.feature-img-path | relative_url }}">
 </div>
 
 <p><strong>{{ page.short-description }}</strong></p>

--- a/_patterns/_template-fr.md
+++ b/_patterns/_template-fr.md
@@ -3,7 +3,6 @@ layout: default
 name: Modèle de test
 short-description: Un modèle pour tester et créer de nouveaux modèles.
 feature-img-path: 
-feature-img-alt: 
 permalink: /modeles/model.html
 lang-link: ../patterns/template.html
 lang: fr

--- a/_patterns/_template.md
+++ b/_patterns/_template.md
@@ -3,7 +3,6 @@ layout: default
 name: Testing Template
 short-description: A template to test and create new patterns.
 feature-img-path: 
-feature-img-alt: 
 permalink: /patterns/template.html
 lang-link: ../modeles/model.html
 lang: en

--- a/_patterns/opt-in-fr.md
+++ b/_patterns/opt-in-fr.md
@@ -3,7 +3,6 @@ layout: default
 name: Opter pour donner son consentement
 short-description: Informer l'utilisateur de la collecte de données et lui demander de donner son consentement.
 feature-img-path: assets/images/opt-in-fr.png
-feature-img-alt: Politique de confidentialité avec une case à cocher pour l'acceptation et un bouton d'envoi.
 permalink: /modeles/opter.html
 lang-link: ../patterns/optin.html
 lang: fr

--- a/_patterns/opt-in.md
+++ b/_patterns/opt-in.md
@@ -3,7 +3,6 @@ layout: default
 name: Opt-in to give consent
 short-description: Notifying the user of data collection and asking them to consent to it.
 feature-img-path: assets/images/opt-in.png
-feature-img-alt: Privacy policy with with checkbox prompt to agree and submit button.
 permalink: /patterns/optin.html
 lang-link: ../modeles/opter.html
 lang: en


### PR DESCRIPTION
Removing the alt text on the images marks them as decorative and as the descriptions around it are sufficient to describing what's shown on the image, they are not needed.

Fixes: 
https://jira-dev.bdm-dev.dts-stn.com/browse/SAEB-218
https://jira-dev.bdm-dev.dts-stn.com/browse/SAEB-211